### PR TITLE
nose.eq_ -> assert

### DIFF
--- a/jsonable/tests/test_functions.py
+++ b/jsonable/tests/test_functions.py
@@ -1,7 +1,5 @@
 from collections import deque
 
-from nose.tools import eq_
-
 from ..functions import to_json
 from ..type import Type
 
@@ -9,20 +7,20 @@ from ..type import Type
 def test_to_json():
 
     # Basic JSON types
-    eq_(to_json(5), 5)
-    eq_(to_json(5.5), 5.5)
-    eq_(to_json("five"), "five")
-    eq_(to_json(True), True)
-    eq_(to_json(None), None)
+    assert to_json(5) == 5
+    assert to_json(5.5) == 5.5
+    assert to_json("five") == "five"
+    assert to_json(True) == True
+    assert to_json(None) == None
 
     # Iterable types
-    eq_(to_json(["foo", 5.5]), ["foo", 5.5])
-    eq_(to_json(("foo", 5.5)), ["foo", 5.5])
-    eq_(set(to_json({"foo", 5.5})), {"foo", 5.5})
-    eq_(to_json(deque(["foo", 5.5])), ["foo", 5.5])
+    assert to_json(["foo", 5.5]) == ["foo", 5.5]
+    assert to_json(("foo", 5.5)) == ["foo", 5.5]
+    assert set(to_json({"foo", 5.5})) == {"foo", 5.5}
+    assert to_json(deque(["foo", 5.5])) == ["foo", 5.5]
 
     # Dict type
-    eq_(to_json({"foo": 5.5}), {"foo": 5.5})
+    assert to_json({"foo": 5.5}) == {"foo": 5.5}
 
     # jsonable.Type
     class Foo(Type):
@@ -32,4 +30,4 @@ def test_to_json():
             self.bar = int(bar)
 
     foo = Foo(5)
-    eq_(to_json(foo), foo.to_json())
+    assert to_json(foo) == foo.to_json()

--- a/jsonable/tests/test_instance.py
+++ b/jsonable/tests/test_instance.py
@@ -1,23 +1,19 @@
-from nose.tools import eq_
-
 from .. import instance
 
 
 def test_simple_repr():
     
-    eq_(
-        instance.simple_repr("Classname", 'foo', 5, herp=[5]),
-        "Classname('foo', 5, herp=[5])"
-    )
+    assert (
+        instance.simple_repr("Classname", 'foo', 5, herp=[5]) ==
+        "Classname('foo', 5, herp=[5])")
     
-    eq_(
+    assert (
         instance.simple_repr("Classname",
                              ordered_kwargs=[('foo', "foo"),
                                              ('five', 5),
                                              ('herp', [5]),
-                                             ('derp', 20)]),
-        "Classname(foo='foo', five=5, herp=[5], derp=20)"
-    )
+                                             ('derp', 20)]) ==
+        "Classname(foo='foo', five=5, herp=[5], derp=20)")
 
 def test_slots_repr():
     
@@ -36,10 +32,9 @@ def test_slots_repr():
             self.derp = derp
         
     
-    eq_(
-        instance.slots_repr(SubSlottedItem("foo", 5, [5], 20)),
-        "SubSlottedItem(foo='foo', five=5, herp=[5], derp=20)"
-    )
+    assert (
+        instance.slots_repr(SubSlottedItem("foo", 5, [5], 20)) ==
+        "SubSlottedItem(foo='foo', five=5, herp=[5], derp=20)")
 
 def test_slots_items():
     
@@ -58,10 +53,9 @@ def test_slots_items():
             self.derp = derp
         
     
-    eq_(
-        list(instance.slots_items(SubSlottedItem("foo", 5, [5], 20))),
-        [("foo", "foo"), ("five", 5), ("herp", [5]), ("derp", 20)]
-    )
+    assert (
+        list(instance.slots_items(SubSlottedItem("foo", 5, [5], 20))) ==
+        [("foo", "foo"), ("five", 5), ("herp", [5]), ("derp", 20)])
 
 def test_slots_keys():
     
@@ -80,7 +74,6 @@ def test_slots_keys():
             self.derp = derp
         
     
-    eq_(
-        list(instance.slots_keys(SubSlottedItem("foo", 5, [5], 20))),
-        ["foo", "five", "herp", "derp"]
-    )
+    assert (
+        list(instance.slots_keys(SubSlottedItem("foo", 5, [5], 20))) ==
+        ["foo", "five", "herp", "derp"])

--- a/jsonable/tests/test_self_constructor.py
+++ b/jsonable/tests/test_self_constructor.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_
-
 from ..self_constructor import SelfConstructor
 
 
@@ -15,7 +13,7 @@ def test_self_construction():
     derp = "foo"
     foo = Foo(herp, derp)
     
-    eq_(foo.herp, herp)
-    eq_(foo.derp, derp)
+    assert foo.herp == herp
+    assert foo.derp == derp
     
-    eq_(foo, Foo(foo))
+    assert foo == Foo(foo)

--- a/jsonable/tests/test_type.py
+++ b/jsonable/tests/test_type.py
@@ -1,7 +1,5 @@
 import pickle
 
-from nose.tools import eq_
-
 from ..type import Base, Type
 
 
@@ -31,16 +29,16 @@ def test_construction_and_variables():
     bars = [Bar("string", 334.34), Bar(False, {"derp": 3.1})]
     foo = Foo(herp, bars)
 
-    eq_(foo.herp, herp)
-    eq_(foo.bars, bars)
-    eq_(foo, Foo(foo))
-    eq_(foo, Foo(foo.to_json()))
+    assert foo.herp == herp
+    assert foo.bars == bars
+    assert foo == Foo(foo)
+    assert foo == Foo(foo.to_json())
 
 
 def test_pickle():
     bar = ExampleJSONable("wat", "herp")
 
-    eq_(bar, pickle.loads(pickle.dumps(bar)))
+    assert bar == pickle.loads(pickle.dumps(bar))
 
 
 def test_repr():
@@ -53,10 +51,9 @@ def test_repr():
 
     bar = Bar(1, "two")
 
-    eq_(
-        repr(bar),
-        "Bar(subherp=1, subderp='two')"
-    )
+    assert (
+        repr(bar) ==
+        "Bar(subherp=1, subderp='two')")
 
 
 def test_abstract_construction_and_variables():
@@ -101,4 +98,4 @@ def test_abstract_construction_and_variables():
     bowl = Bowl([apple, orange])
 
     print(Fruit.REGISTERED_SUB_CLASSES)
-    eq_(bowl, Bowl(bowl.to_json()))
+    assert bowl == Bowl(bowl.to_json())


### PR DESCRIPTION
Makes the assertions in the tests directory straight python assertions, allowing use of pytest instead of the now-deprecated nose test runner. There are no test behavior changes.